### PR TITLE
Refresh the popup window instead of always creating another one

### DIFF
--- a/source/scripts/popup.js
+++ b/source/scripts/popup.js
@@ -54,7 +54,8 @@ function openPopup(artist, song, lyrics){
 		// instead of creating another window
 		var lyricsPopup = window.open(
 			'../pages/popup_window.html',
-			'play-music-lyrics-fetcher-window'
+			'play-music-lyrics-fetcher-window',
+			'width='+($(window).width()+30)+', height='+($(window).height()-20)
 		);
 		lyricsPopup.focus();
 		

--- a/source/scripts/popup.js
+++ b/source/scripts/popup.js
@@ -47,13 +47,19 @@ chrome.storage.sync.get('display_new_window', function(obj) {
 
 
 function openPopup(artist, song, lyrics){
-
 	chrome.runtime.getBackgroundPage(function(bgWindow) {
 		bgWindow.storeBackgroundTempData(artist, song, lyrics);
-		chrome.windows.create({'url': '../pages/popup_window.html', 'type': 'detached_panel', 'width': $(window).width()+30, 'height': $(window).height()-20, 'focused':true });
+		
+		// if there is a window with the same id, it'll be refreshed
+		// instead of creating another window
+		var lyricsPopup = window.open(
+			'../pages/popup_window.html',
+			'play-music-lyrics-fetcher-window'
+		);
+		lyricsPopup.focus();
+		
 		window.close();
 	});
-
 }
 
 function restart(){


### PR DESCRIPTION
Solves #1 by using window.open with the same WindowID instead of chrome.windows API (which always creates a new window)